### PR TITLE
Add escpos status support

### DIFF
--- a/ZplEscPrinter/js/main.js
+++ b/ZplEscPrinter/js/main.js
@@ -157,6 +157,22 @@ async function zpl(data){
 const escposStatusCommand = `\u0010\u0004\x01`;
 
 /**
+ * @returns {number[]} - The status byte for the escpos printer
+ */
+function getEscposStatus() {
+    let returnBytes = [0x00];
+    if (![1, '1', true, 'true'].includes(configs.escposOnline)) {
+        // Bit 3 set indicates that the printer is offline
+        returnBytes[0] |= 0b00001000;
+    }
+    if ([1, '1', true, 'true'].includes(configs.escposPaperFeedPressed)) {
+        // Bit 6 set indicates that the paper feed button is pressed
+        returnBytes[0] |= 0b01000000;
+    }
+    return returnBytes
+}
+
+/**
  * 
  * @param {string} data - The incoming socket data from the client
  * @param {boolean} b64 - If true, data is base64 encoded
@@ -168,7 +184,7 @@ async function escpos(data,b64){
 
     if (dataAux === escposStatusCommand) {
         // This returns the everything okay status
-        return Buffer.from([0b00001000]);
+        return Buffer.from(getEscposStatus());
     }
 
     if (!dataAux || !dataAux.trim().length) {

--- a/ZplEscPrinter/js/main.js
+++ b/ZplEscPrinter/js/main.js
@@ -23,7 +23,9 @@ const defaults = {
     saveLabels: false,
     filetype: '3',
     path: null,
-    counter: 0
+    counter: 0,
+    escposOnline: true,
+    escposPaperFeedPressed: false,
 };
 
 $(function () {

--- a/ZplEscPrinter/main.html
+++ b/ZplEscPrinter/main.html
@@ -195,6 +195,33 @@
                                 <button id="btn-path" type="button" class="btn btn-secondary">Choose</button>
                             </div>
                         </fieldset>
+                        <fieldset class="border rounded p-2 mb-1">
+                            <legend class="float-none w-auto px-2 mb-0 fs-6 fw-semibold">ESC/POS Status</legend>
+                            <div class="row mb-2">
+                                <div class="col-8">
+                                    <div class="input-group">
+                                        <span class="input-group-text">
+                                            <div class="form-check">
+                                                <input id="escposOnline" type="checkbox" class="form-check-input _big">
+                                                <label class="form-check-label" for="escposOnline">Online</label>
+                                            </div>
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row mb-2">
+                                <div class="col-4">
+                                    <div class="input-group">
+                                        <span class="input-group-text">
+                                            <div class="form-check">
+                                                <input id="escposPaperFeedPressed" type="checkbox" class="form-check-input _big">
+                                                <label class="form-check-label" for="escposPaperFeedPressed">Paper Feed Pressed</label>
+                                            </div>
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </fieldset>
                     </div>
                     <div class="modal-footer p-1">
                         <button id="btn-close-save-settings" type="button" class="btn btn-secondary btn-close-save-settings" data-bs-dismiss="modal"><i class="glyphicon glyphicon-remove"></i> Close</button>

--- a/ZplEscPrinter/main.html
+++ b/ZplEscPrinter/main.html
@@ -195,7 +195,7 @@
                                 <button id="btn-path" type="button" class="btn btn-secondary">Choose</button>
                             </div>
                         </fieldset>
-                        <fieldset class="border rounded p-2 mb-1">
+                        <fieldset class="border rounded p-2 mb-1 is-esc">
                             <legend class="float-none w-auto px-2 mb-0 fs-6 fw-semibold">ESC/POS Status</legend>
                             <div class="row mb-2">
                                 <div class="col-8">

--- a/ZplEscPrinter/main.html
+++ b/ZplEscPrinter/main.html
@@ -198,7 +198,7 @@
                         <fieldset class="border rounded p-2 mb-1 is-esc">
                             <legend class="float-none w-auto px-2 mb-0 fs-6 fw-semibold">ESC/POS Status</legend>
                             <div class="row mb-2">
-                                <div class="col-8">
+                                <div class="col">
                                     <div class="input-group">
                                         <span class="input-group-text">
                                             <div class="form-check">
@@ -208,14 +208,22 @@
                                         </span>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="row mb-2">
-                                <div class="col-4">
+                                <div class="col">
                                     <div class="input-group">
                                         <span class="input-group-text">
                                             <div class="form-check">
                                                 <input id="escposPaperFeedPressed" type="checkbox" class="form-check-input _big">
                                                 <label class="form-check-label" for="escposPaperFeedPressed">Paper Feed Pressed</label>
+                                            </div>
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="col">
+                                    <div class="input-group">
+                                        <span class="input-group-text">
+                                            <div class="form-check">
+                                                <input id="escposPaperFeedPressed" type="checkbox" class="form-check-input _big">
+                                                <label class="form-check-label" for="escposPaperFeedPressed">Status 5</label>
                                             </div>
                                         </span>
                                     </div>


### PR DESCRIPTION
The esc/pos command set supports the status command, which the printer then responds to with status bytes which indicates the printer status.

This PR implements support for the first status byte, and adds configuration for changing the online and paper feed pressed statuses

![image](https://github.com/user-attachments/assets/8e781d17-164d-4209-aeca-afc5280d8cb0)
